### PR TITLE
[Add] 오늘 최저가 상품 조회, 오늘 최저가 상품 카테고리별 수 조회 API추가

### DIFF
--- a/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
@@ -58,4 +58,36 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
           + "group by p1.product_id having count(p2.created_date) > 1 and percent > 1) t group by category",
       nativeQuery = true)
   List<Object[]> countDiscountProductEachCategory(LocalDate date);
+
+  @Query(value =
+      "select p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date, today_price, max_price from \n"
+          + "(SELECT p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date,\n"
+          + " min(p2.price + p2.coupon) as min_price, max(p2.price + p2.coupon) as max_price\n"
+          + "FROM product p1 \n"
+          + "inner join price p2 on p1.product_id = p2.product_id\n"
+          + "where p1.category = ?1\n"
+          + "group by p1.product_id having min_price != max_price and count(p2.created_date) > 5) p1\n"
+          + "inner join \n"
+          + "(SELECT p1.product_id, p1.price as today_price\n"
+          + "FROM price p1 \n"
+          + "where p1.created_date > ?2) p2\n"
+          + "on p1.product_id = p2.product_id\n"
+          + "where min_price = today_price\n"
+          + "order by (max_price - min_price)/max_price DESC",
+      countQuery ="select count(*) from \n"
+          + "(SELECT p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date,\n"
+          + " min(p2.price + p2.coupon) as min_price, max(p2.price + p2.coupon) as max_price\n"
+          + "FROM product p1 \n"
+          + "inner join price p2 on p1.product_id = p2.product_id\n"
+          + "where p1.category = ?1\n"
+          + "group by p1.product_id having min_price != max_price and count(p2.created_date) > 5) p1\n"
+          + "inner join \n"
+          + "(SELECT p1.product_id, p1.price as today_price\n"
+          + "FROM price p1 \n"
+          + "where p1.created_date > ?2) p2\n"
+          + "on p1.product_id = p2.product_id\n"
+          + "where min_price = today_price",
+      nativeQuery = true)
+  Page<Object[]> findProductByMinimumPrice(String category, LocalDate date, Pageable pageable);
+
 }

--- a/src/main/java/com/musinsa/watcher/service/ProductService.java
+++ b/src/main/java/com/musinsa/watcher/service/ProductService.java
@@ -4,9 +4,11 @@ import com.musinsa.watcher.MapperUtils;
 import com.musinsa.watcher.domain.product.Product;
 import com.musinsa.watcher.domain.product.ProductRepository;
 import com.musinsa.watcher.web.dto.DiscountedProductDto;
+import com.musinsa.watcher.web.dto.MinimumPriceProductDto;
 import com.musinsa.watcher.web.dto.ProductResponseDto;
 import com.musinsa.watcher.web.dto.ProductWithPriceResponseDto;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -74,6 +76,16 @@ public class ProductService {
         .findDiscountedProduct(category, findLastUpdateDate(), pageable);
     return new PageImpl<DiscountedProductDto>(
         DiscountedProductDto.objectsToDtoList(page.getContent()),
+        pageable, page.getTotalElements());
+  }
+
+  @Cacheable(value = "productCache", key = "'minimum'+#category+#pageable.pageNumber")
+  public Page<MinimumPriceProductDto> findMinimumPriceProduct(String category, Pageable pageable) {
+    Page<Object[]> page = productRepository
+        .findProductByMinimumPrice(category, findLastUpdateDate(), pageable);
+    log.info(Arrays.toString(page.toList().get(0)));
+    return new PageImpl<MinimumPriceProductDto>(
+        MinimumPriceProductDto.objectsToDtoList(page.getContent()),
         pageable, page.getTotalElements());
   }
 

--- a/src/main/java/com/musinsa/watcher/service/ProductService.java
+++ b/src/main/java/com/musinsa/watcher/service/ProductService.java
@@ -95,6 +95,12 @@ public class ProductService {
     return MapperUtils.objectToStringAndIntegerMap(objectList);
   }
 
+  @Cacheable(value = "productCache", key = "'minimum price list'")
+  public Map<String, Integer> countMinimumPriceProductEachCategory() {
+    List<Object[]> objectList = productRepository.countMinimumPriceProductEachCategory(findLastUpdateDate());
+    return MapperUtils.objectToStringAndIntegerMap(objectList);
+  }
+
   public LocalDate findLastUpdateDate() {
     return productRepository.findLastUpdateDate().toLocalDate();
   }

--- a/src/main/java/com/musinsa/watcher/web/ProductController.java
+++ b/src/main/java/com/musinsa/watcher/web/ProductController.java
@@ -3,6 +3,7 @@ package com.musinsa.watcher.web;
 import com.musinsa.watcher.domain.product.InitialWord;
 import com.musinsa.watcher.service.ProductService;
 import com.musinsa.watcher.web.dto.DiscountedProductDto;
+import com.musinsa.watcher.web.dto.MinimumPriceProductDto;
 import com.musinsa.watcher.web.dto.ProductResponseDto;
 import com.musinsa.watcher.web.dto.ProductWithPriceResponseDto;
 import java.util.Map;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @EnableCaching
-@CrossOrigin("http://www.musinsa.cf/")
+@CrossOrigin({"http://www.musinsa.cf/", })
 @RequiredArgsConstructor
 @RestController
 public class ProductController {
@@ -49,6 +50,12 @@ public class ProductController {
   public Page<DiscountedProductDto> findDiscountedProduct(
       @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page, String category) {
     return productService.findDiscountedProduct(category, PageRequest.of(page, 25));
+  }
+
+  @GetMapping("/api/v1/product/minimum")
+  public Page<MinimumPriceProductDto> findMinimumPriceProduct(
+      @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page, String category) {
+    return productService.findMinimumPriceProduct(category, PageRequest.of(page, 25));
   }
 
   @GetMapping("/api/v1/product/discount/list")

--- a/src/main/java/com/musinsa/watcher/web/ProductController.java
+++ b/src/main/java/com/musinsa/watcher/web/ProductController.java
@@ -63,6 +63,11 @@ public class ProductController {
     return productService.countDiscountProductEachCategory();
   }
 
+  @GetMapping("/api/v1/product/minimum/list")
+  public Map<String, Integer> findMinimumPriceProduct() {
+    return productService.countMinimumPriceProductEachCategory();
+  }
+
   @GetMapping("/api/v1/product/brand")
   public Page<ProductResponseDto> findProductByBrand(
       @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page, String name) {

--- a/src/main/java/com/musinsa/watcher/web/dto/MinimumPriceProductDto.java
+++ b/src/main/java/com/musinsa/watcher/web/dto/MinimumPriceProductDto.java
@@ -1,0 +1,52 @@
+package com.musinsa.watcher.web.dto;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MinimumPriceProductDto {
+
+  private int productId;
+  private String productName;
+  private String brand;
+  private String img;
+  private LocalDate modifiedDate;
+  private long today_price;
+  private long maxPrice;
+
+  @Builder
+  public MinimumPriceProductDto(int productId, String productName, String brand,
+      String img, Timestamp modifiedDate, long today_price, long maxPrice) {
+    this.productId = productId;
+    this.productName = productName;
+    this.today_price = today_price;
+    this.maxPrice = maxPrice;
+    this.brand = brand;
+    this.img = img;
+    this.modifiedDate = modifiedDate.toLocalDateTime().toLocalDate();
+  }
+
+  public static MinimumPriceProductDto objectToDto(Object[] object) {
+    return MinimumPriceProductDto
+        .builder()
+        .productId((int) object[0])
+        .productName((String) object[1])
+        .brand((String) object[2])
+        .img((String) object[3])
+        .modifiedDate((Timestamp) object[4])
+        .today_price(((Integer) object[5]).longValue())
+        .maxPrice(((BigInteger) object[6]).longValue())
+        .build();
+  }
+
+  public static List<MinimumPriceProductDto> objectsToDtoList(List<Object[]> objectList) {
+    return objectList.stream()
+        .map(product -> MinimumPriceProductDto.objectToDto(product))
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
### 목적
오늘 최저가 상품 조회

### 원인
무신사가 현재 파이널 세일기간이다. 가격이 많이 낮춰졌음에도 불구하고 오늘 할인 상품은 전날 대비로 보여주기때문에 어제 할인된 상품을 오늘도 볼 수 없다. 

### 내용

1. 오늘 가격이 최저가 상품 조회
2. 오늘 가격이 최저가 상품 카테고리별 수 조회 API추가