### PR TITLE
[Fix] 카테고리 전환시 아이템이 nan으로 표시되는 문제 수정, 아이템 클릭시 화면 상단으로 이동

### DIFF
--- a/frontend/src/components/ProductList.vue
+++ b/frontend/src/components/ProductList.vue
@@ -17,7 +17,7 @@
                         v-if="product.discount !=null">-{{Math.ceil(product.percent)}}%</h6>
                     <h6
                         style="color : rgb(234 7 7); position: absolute; top: 0px; left: 0px; background-color:#FFF"
-                        v-if="currentListTopic == 'minimum'">-{{Math.ceil((product.maxPrice - product.today_price) * 100/product.maxPrice)}}%</h6>
+                        v-if="currentListTopic == 'minimum' && product.today_price != null">-{{Math.ceil((product.maxPrice - product.today_price) * 100/product.maxPrice)}}%</h6>
                     <h6
                         style="position: absolute; top: 0; left: 5px; background-color:#FFF"
                         v-if="product.discount ==null && currentListTopic != 'minimum'">
@@ -39,7 +39,7 @@
                                     <strong>{{numberToPrice(product.price)}}원</strong>
                                 </span>
                             </div>
-                            <div v-if="currentListTopic == 'minimum'">
+                            <div v-if="currentListTopic == 'minimum' && product.today_price != null">
                                 <span style="text-decoration: line-through; color :#b2b2b2; margin-right:5px">{{numberToPrice(product.maxPrice)}}원</span>
                                 <span style="color:#ae0000">
                                     <strong>{{numberToPrice(product.today_price)}}원</strong>
@@ -104,6 +104,7 @@
                         },
                         params: product
                     })
+                window.scrollTo(0, 0)
             },
             truncateProductName(productName) {
                 return productName.length > 60


### PR DESCRIPTION
### 목적
오류 수정
### 원인
카테고리시 아이템에 nan값이 출력됨, 아이템 클릭시 화면 상단으로 이동하지 않음
### 내용

1. 카테고리 전환시 아이템이 nan으로 표시되는 문제 수정,
2. 아이템 클릭시 화면 상단으로 이동
