### PR TITLE
[Add] 유저 api접근 log추가

### DIFF
--- a/src/main/java/com/musinsa/watcher/WatcherApplication.java
+++ b/src/main/java/com/musinsa/watcher/WatcherApplication.java
@@ -3,8 +3,10 @@ package com.musinsa.watcher;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableCaching
+@EnableJpaAuditing
 @SpringBootApplication
 public class WatcherApplication {
 

--- a/src/main/java/com/musinsa/watcher/config/LogConfig.java
+++ b/src/main/java/com/musinsa/watcher/config/LogConfig.java
@@ -1,0 +1,22 @@
+package com.musinsa.watcher.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import java.util.List;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class LogConfig implements WebMvcConfigurer {
+
+  private final LogInterceptor logInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(logInterceptor)
+        .addPathPatterns("/**");
+  }
+
+}

--- a/src/main/java/com/musinsa/watcher/config/LogInterceptor.java
+++ b/src/main/java/com/musinsa/watcher/config/LogInterceptor.java
@@ -1,0 +1,46 @@
+package com.musinsa.watcher.config;
+
+import com.musinsa.watcher.domain.log.AccessLog;
+import com.musinsa.watcher.domain.log.AccessLogRepository;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class LogInterceptor extends HandlerInterceptorAdapter {
+
+  private final AccessLogRepository accessLogRepository;
+  private final String OUTBOUND_URI = "/api/product/link";
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    if (!request.getRequestURI().equals(OUTBOUND_URI) && handler instanceof HandlerMethod == false) {
+      return true;
+    }
+    accessLogRepository.save(AccessLog.builder()
+        .ip(getRemoteAddr(request))
+        .agent(request.getHeader("User-Agent"))
+        .url(request.getRequestURI())
+        .parameter(request.getQueryString())
+        .build());
+    if (request.getRequestURI().equals(OUTBOUND_URI)) {
+      response.setStatus(HttpStatus.OK.value());
+      return false;
+    }
+    return true;
+  }
+
+  private String getRemoteAddr(HttpServletRequest request) {
+    return (null != request.getHeader("X-FORWARDED-FOR")) ? request.getHeader("X-FORWARDED-FOR")
+        : request.getRemoteAddr();
+  }
+
+}

--- a/src/main/java/com/musinsa/watcher/domain/BaseTimeEntity.java
+++ b/src/main/java/com/musinsa/watcher/domain/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.musinsa.watcher.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+}

--- a/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
+++ b/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
@@ -1,0 +1,44 @@
+package com.musinsa.watcher.domain.log;
+
+import com.musinsa.watcher.domain.BaseTimeEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class AccessLog extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String ip;
+
+  @Column(nullable = false)
+  private String agent;
+
+  @Column(nullable = false)
+  private String url;
+
+  private String brand;
+
+  private String product_name;
+
+  @Builder
+  public AccessLog(String ip, String agent, String url, String brand, String product_name) {
+    this.ip=ip;
+    this.agent=agent;
+    this.url=url;
+    this.brand=brand;
+    this.product_name=product_name;
+  }
+
+}

--- a/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
+++ b/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
@@ -28,17 +28,14 @@ public class AccessLog extends BaseTimeEntity {
   @Column(nullable = false)
   private String url;
 
-  private String brand;
-
-  private String product_name;
+  private String parameter;
 
   @Builder
-  public AccessLog(String ip, String agent, String url, String brand, String product_name) {
+  public AccessLog(String ip, String agent, String url, String parameter) {
     this.ip=ip;
     this.agent=agent;
     this.url=url;
-    this.brand=brand;
-    this.product_name=product_name;
+    this.parameter=parameter;
   }
 
 }

--- a/src/main/java/com/musinsa/watcher/domain/log/AccessLogRepository.java
+++ b/src/main/java/com/musinsa/watcher/domain/log/AccessLogRepository.java
@@ -1,0 +1,7 @@
+package com.musinsa.watcher.domain.log;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessLogRepository extends JpaRepository<AccessLog, Long> {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.jpa.hibernate.ddl-auto=none
-spring.jpa.show_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
+
+spring.profiles.include=dev

--- a/src/test/java/com/musinsa/watcher/web/PriceControllerTest.java
+++ b/src/test/java/com/musinsa/watcher/web/PriceControllerTest.java
@@ -1,5 +1,6 @@
 package com.musinsa.watcher.web;
 
+import com.musinsa.watcher.config.LogInterceptor;
 import com.musinsa.watcher.service.PriceService;
 import com.musinsa.watcher.web.dto.PriceResponseDto;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.junit.Test;
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @RunWith(SpringRunner.class)
+@MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(controllers = PriceController.class)
 public class PriceControllerTest {
 
@@ -31,6 +34,9 @@ public class PriceControllerTest {
   @MockBean
   private PriceService priceService;
 
+  @MockBean
+  private LogInterceptor logInterceptor;
+
   private final String API = "/api/v1/product/";
 
   @Test
@@ -38,6 +44,7 @@ public class PriceControllerTest {
   public void 상품_상세정보_조회() throws Exception {
     int productId = 1234;
     Page<PriceResponseDto> mockPage = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(priceService.findByProductId(eq(productId), any())).thenReturn(mockPage);
     mvc.perform(get(API + "price")
         .param("id", Integer.toString(productId)))

--- a/src/test/java/com/musinsa/watcher/web/ProductControllerTest.java
+++ b/src/test/java/com/musinsa/watcher/web/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.musinsa.watcher.web;
 
+import com.musinsa.watcher.config.LogInterceptor;
 import com.musinsa.watcher.domain.product.InitialWord;
 import com.musinsa.watcher.service.ProductService;
 import com.musinsa.watcher.web.dto.DiscountedProductDto;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.junit.Test;
@@ -28,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @RunWith(SpringRunner.class)
+@MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(controllers = ProductController.class)
 public class ProductControllerTest {
 
@@ -37,12 +40,16 @@ public class ProductControllerTest {
   @MockBean
   private ProductService mockProductService;
 
+  @MockBean
+  private LogInterceptor logInterceptor;
+
   private final String API = "/api/v1/product/";
 
   @Test
   @DisplayName("브랜드 리스트 조회")
   public void 브랜드_리스트_조회() throws Exception {
     Page<String> mockPage = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findAllBrand(any())).thenReturn(mockPage);
     mvc.perform(get("/api/v1/search/brands/list"))
         .andExpect(status().isOk());
@@ -54,6 +61,7 @@ public class ProductControllerTest {
   public void 브랜드_상품_리스트_조회() throws Exception {
     String brandName = "good brand";
     Page<ProductResponseDto> mockPage = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findByBrand(eq(brandName), any())).thenReturn(mockPage);
     mvc.perform(get(API + "brand")
         .param("name", brandName))
@@ -67,6 +75,7 @@ public class ProductControllerTest {
     String type = "1";
     Map<String, Integer> map = new HashMap<>();
     String[] initial = InitialWord.valueOf(InitialWord.getType(type)).getInitials();
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findBrandByInitial(eq(initial[0]), eq(initial[1]), eq(initial[2]))).thenReturn(map);
     mvc.perform(get( "/api/v1/search/brands")
         .param("type", type))
@@ -81,6 +90,7 @@ public class ProductControllerTest {
     String category2 = "002";
     Page<ProductResponseDto> mockPage1 = mock(Page.class);
     Page<ProductResponseDto> mockPage2 = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findByCategory(eq(category1), any())).thenReturn(mockPage1);
     when(mockProductService.findByCategory(eq(category2), any())).thenReturn(mockPage2);
     mvc.perform(get(API + "list")
@@ -98,6 +108,7 @@ public class ProductControllerTest {
   public void 할인_품목_조회() throws Exception {
     String category = "001";
     Page<DiscountedProductDto> mockPage = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findDiscountedProduct(eq(category), any())).thenReturn(mockPage);
     mvc.perform(get(API + "discount")
         .param("category", category))
@@ -110,6 +121,7 @@ public class ProductControllerTest {
   public void 검색_품목_조회() throws Exception {
     String topic = "셔츠";
     Page<ProductResponseDto> mockPage = mock(Page.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.searchItems(eq(topic), any())).thenReturn(mockPage);
     mvc.perform(get("/api/v1/search")
         .param("topic", topic))
@@ -122,6 +134,7 @@ public class ProductControllerTest {
   public void 품목_상세_정보_조회() throws Exception {
     int productId = 1;
     ProductWithPriceResponseDto mockDto = mock(ProductWithPriceResponseDto.class);
+    when(logInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     when(mockProductService.findProductWithPrice(eq(productId))).thenReturn(mockDto);
     mvc.perform(get(API)
         .param("id", Integer.toString(productId)))


### PR DESCRIPTION
### 목적
유저 접속에 따른 log기록 추가를 위함
### 원인
사이트를 통해 무신사로 접속하는 outbound 산정을 위함
### 내용

1. access log 엔티티 작성
2. 인터셉트를 통한 유저 log 저장
3. controller test코드에서 인터셉터와 의존성을 갖는 문제 수정
4. production 서버에서 sql로그가 찍히는 문제 수정