### PR TITLE
[Fix] 배포시 사용되는 shell script 오류 수정

### DIFF
--- a/.github/workflows/spring-deploy.yml
+++ b/.github/workflows/spring-deploy.yml
@@ -1,9 +1,6 @@
 name: spring boot deploy
 
 on:
-  push:
-    branches: [ backend-dev ]
-
   pull_request:
     types: [ closed ]
     branches: [ backend-release ]

--- a/.github/workflows/spring-deploy.yml
+++ b/.github/workflows/spring-deploy.yml
@@ -1,6 +1,9 @@
 name: spring boot deploy
 
 on:
+  push:
+    branches: [ backend-dev ]
+
   pull_request:
     types: [ closed ]
     branches: [ backend-release ]
@@ -68,7 +71,7 @@ jobs:
           port: ${{ secrets.NCP_SERVER1_PORT }}
           script: |
             cd deploy
-            sudo bash deploy.sh 
+            sudo bash deploy.sh
 
       - name: AWS sever1 scp deploy folder
         uses: appleboy/scp-action@master
@@ -88,6 +91,28 @@ jobs:
           username: ${{ secrets.AWS_SERVER1_USERNAME }}
           password: ${{ secrets.AWS_SERVER1_PASSWORD }}
           port: ${{ secrets.AWS_SERVER1_PORT }}
+          script: |
+            cd deploy
+            sudo bash deploy.sh
+
+      - name: AWS sever2 scp deploy folder
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.AWS_SERVER2_HOST }}
+          username: ${{ secrets.AWS_SERVER2_USERNAME }}
+          password: ${{ secrets.AWS_SERVER2_PASSWORD }}
+          port: ${{ secrets.AWS_SERVER2_PORT }}
+          source: "./deploy/*"
+          target: "~/"
+          overwrite: true
+
+      - name: AWS sever2 deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_SERVER2_HOST   }}
+          username: ${{ secrets.AWS_SERVER2_USERNAME }}
+          password: ${{ secrets.AWS_SERVER2_PASSWORD }}
+          port: ${{ secrets.AWS_SERVER2_PORT }}
           script: |
             cd deploy
             sudo bash deploy.sh

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -11,11 +11,11 @@ if [ -z ${IDLE_PID} ]
 then
   echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."
 else
-  if [ ${IDLE_PID}=8081 ]
+  if [ ${IDLE_PORT}=8081 ]
   then
     echo "> port : $IDLE_PID로 실행중인 real1을 컨테이너 종료합니다."
     docker-compose kill real1 
-  elif [ ${IDLE_PID}=8082 ]
+  elif [ ${IDLE_PORT}=8082 ]
   then
     echo "> port : $IDLE_PID로 실행중인 real2을 컨테이너 종료합니다."
     docker-compose kill real2 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -11,14 +11,14 @@ if [ -z ${IDLE_PID} ]
 then
   echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."
 else
-  if [ ${IDLE_PORT}=8081 ]
+  if [ ${IDLE_PORT} -eq 8081 ]
   then
     echo "> port : $IDLE_PID로 실행중인 real1을 컨테이너 종료합니다."
-    docker-compose kill real1 
-  elif [ ${IDLE_PORT}=8082 ]
+    #docker-compose kill real1
+  elif [ ${IDLE_PORT} -eq 8082 ]
   then
     echo "> port : $IDLE_PID로 실행중인 real2을 컨테이너 종료합니다."
-    docker-compose kill real2 
+    #docker-compose kill real2
   fi
   sleep 10
 fi


### PR DESCRIPTION
### 목적
서버 배포시 실행되는 shell script를 수정하기위함
### 원인
잘못된 스크립트 문법으로 로직이 뒤섞임
#76  서버
### 내용
1. shell script에서 등가 비교를 =로 하던 부분을 -eq로 변경
2. port정보와 pid 정보를 혼용해 잘못된 로직이 실행되는 문제 수정
3.  서버 증설에 따른 배포 워크 플로우 추가