### PR TITLE
[Update] 테스트 커버리지 최소 값 설정 외 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,19 +40,43 @@ jacocoTestReport {
                     exclude: ["**/QA*", "**/QP*", "**/QB*"])
         }))
     }
-    finalizedBy 'jacocoTestCoverageVerification'
 }
 jacocoTestCoverageVerification {
     violationRules {
         enabled = true
         rule {
             excludes = ["*.QA*", "*.QP*", "*.QB*"]
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
         }
     }
 }
 test {
     useJUnitPlatform()
 }
+
+task testCoverage(type: Test) {
+    group 'verification'
+    description 'Runs the unit tests with coverage'
+
+    dependsOn(':test',
+            ':jacocoTestReport',
+            ':jacocoTestCoverageVerification')
+
+    tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+    tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
 repositories {
     mavenCentral()
     jcenter()

--- a/src/main/java/com/musinsa/watcher/MapperUtils.java
+++ b/src/main/java/com/musinsa/watcher/MapperUtils.java
@@ -1,15 +1,17 @@
 package com.musinsa.watcher;
+
 import java.math.BigInteger;
 import java.util.*;
 
-public class MapperUtils{
+public class MapperUtils {
 
-  private MapperUtils(){
+  private MapperUtils() {
   }
 
-  public static Map<String, Integer> objectToStringAndIntegerMap(List<Object[]> objectList){
+  public static Map<String, Integer> objectToStringAndIntegerMap(List<Object[]> objectList) {
     Map<String, Integer> map = new TreeMap<>();
-    objectList.stream().forEach(object -> map.put((String)object[0], ((BigInteger) object[1]).intValue()));
+    objectList.stream()
+        .forEach(object -> map.put((String) object[0], ((BigInteger) object[1]).intValue()));
     return map;
   }
 

--- a/src/main/java/com/musinsa/watcher/config/LogConfig.java
+++ b/src/main/java/com/musinsa/watcher/config/LogConfig.java
@@ -2,9 +2,7 @@ package com.musinsa.watcher.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import java.util.List;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration

--- a/src/main/java/com/musinsa/watcher/config/LogInterceptor.java
+++ b/src/main/java/com/musinsa/watcher/config/LogInterceptor.java
@@ -22,7 +22,8 @@ public class LogInterceptor extends HandlerInterceptorAdapter {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    if (!request.getRequestURI().equals(OUTBOUND_URI) && handler instanceof HandlerMethod == false) {
+    if (!request.getRequestURI().equals(OUTBOUND_URI)
+        && handler instanceof HandlerMethod == false) {
       return true;
     }
     accessLogRepository.save(AccessLog.builder()

--- a/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
+++ b/src/main/java/com/musinsa/watcher/domain/log/AccessLog.java
@@ -32,10 +32,10 @@ public class AccessLog extends BaseTimeEntity {
 
   @Builder
   public AccessLog(String ip, String agent, String url, String parameter) {
-    this.ip=ip;
-    this.agent=agent;
-    this.url=url;
-    this.parameter=parameter;
+    this.ip = ip;
+    this.agent = agent;
+    this.url = url;
+    this.parameter = parameter;
   }
 
 }

--- a/src/main/java/com/musinsa/watcher/domain/price/Price.java
+++ b/src/main/java/com/musinsa/watcher/domain/price/Price.java
@@ -2,7 +2,6 @@ package com.musinsa.watcher.domain.price;
 
 import com.musinsa.watcher.domain.BaseTimeEntity;
 import com.musinsa.watcher.domain.product.Product;
-import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
@@ -16,7 +15,6 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 
 @NoArgsConstructor
 @Getter

--- a/src/main/java/com/musinsa/watcher/domain/price/PriceRepository.java
+++ b/src/main/java/com/musinsa/watcher/domain/price/PriceRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import java.util.List;
 
 public interface PriceRepository extends JpaRepository<Price, Long> {
 

--- a/src/main/java/com/musinsa/watcher/domain/product/Initial.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/Initial.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class Initial {
+
   private final String RLIKE;
   private final String START;
   private final String END;

--- a/src/main/java/com/musinsa/watcher/domain/product/InitialWord.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/InitialWord.java
@@ -23,7 +23,7 @@ public enum InitialWord {
     this.initials = initials;
   }
 
-  public static String getType(String number){
+  public static String getType(String number) {
     return "type".concat(number);
   }
 

--- a/src/main/java/com/musinsa/watcher/domain/product/Product.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/Product.java
@@ -1,6 +1,5 @@
 package com.musinsa.watcher.domain.product;
 
-import com.musinsa.watcher.domain.BaseTimeEntity;
 import com.musinsa.watcher.domain.price.Price;
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -17,7 +16,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @NoArgsConstructor
 @Getter

--- a/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
@@ -1,7 +1,6 @@
 package com.musinsa.watcher.domain.product;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -62,7 +61,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
           + "on p1.product_id = p2.product_id\n"
           + "where min_price = today_price\n"
           + "order by (max_price - min_price)/max_price DESC",
-      countQuery ="select count(*) from \n"
+      countQuery = "select count(*) from \n"
           + "(SELECT p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date,\n"
           + " min(p2.price + p2.coupon) as min_price, max(p2.price + p2.coupon) as max_price\n"
           + "FROM product p1 \n"

--- a/src/main/java/com/musinsa/watcher/service/CacheService.java
+++ b/src/main/java/com/musinsa/watcher/service/CacheService.java
@@ -1,13 +1,11 @@
 package com.musinsa.watcher.service;
 
 import com.musinsa.watcher.domain.product.ProductQueryRepository;
-import com.musinsa.watcher.domain.product.ProductRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -34,7 +32,7 @@ public class CacheService {
     return cachedLocalDateTime.toLocalDate();
   }
 
-  public LocalDate getLastUpdatedByCache() {
+  public LocalDate getLastUpdatedDate() {
     if (cacheManager.getCache("productCache").get(DATE_KEY) != null) {
       LocalDateTime cachedLocalDateTime = (LocalDateTime) cacheManager.getCache("productCache")
           .get(DATE_KEY).get();
@@ -44,5 +42,4 @@ public class CacheService {
     cacheManager.getCache("productCache").putIfAbsent(DATE_KEY, localDateTime);
     return localDateTime.toLocalDate();
   }
-
 }

--- a/src/main/java/com/musinsa/watcher/web/CacheController.java
+++ b/src/main/java/com/musinsa/watcher/web/CacheController.java
@@ -1,7 +1,6 @@
 package com.musinsa.watcher.web;
 
 import com.musinsa.watcher.service.CacheService;
-import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +20,6 @@ public class CacheController {
 
   @GetMapping("/api/v1/product/cache/last-modified")
   public String updateDate() {
-    return cacheService.getLastUpdatedByCache().toString();
+    return cacheService.getLastUpdatedDate().toString();
   }
 }

--- a/src/test/java/com/musinsa/watcher/domain/product/ProductQueryRepositoryTest.java
+++ b/src/test/java/com/musinsa/watcher/domain/product/ProductQueryRepositoryTest.java
@@ -68,15 +68,81 @@ public class ProductQueryRepositoryTest {
           .modifiedDate(LocalDateTime.now())
           .build());
     }
+  }
 
+  @Test
+  @DisplayName("잘못된 검색어를 조회한다.")
+  public void findByValidTopic() {
+    String searchText = "양말";
+    for (int i = 0; i < 10; i++) {
+      productRepository.save(Product.builder()
+          .productId(i)
+          .productName("고급 신발")
+          .brand("고급 브랜드")
+          .category("001")
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+      productRepository.save(Product.builder()
+          .productId(10 + i)
+          .productName("모자")
+          .brand("신발 최강")
+          .category("003")
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+      productRepository.save(Product.builder()
+          .productId(20 + i)
+          .productName("편한 셔츠")
+          .brand("일반 브랜드")
+          .category("002")
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+    }
     Page<ProductResponseDto> productPage = productQueryRepository
         .searchItems(searchText, PageRequest.of(0, 10));
     List<ProductResponseDto> productList = productPage.getContent();
-    assertEquals(productPage.getTotalElements(), 20);
-    productList.stream().forEach(i -> assertTrue(
-        i.getProductName().contains(searchText) ||
-            i.getBrand().contains(searchText)
-    ));
+    assertEquals(productPage.getTotalElements(), 0);
+    assertEquals(productList.size(), 0);
+  }
+
+  @Test
+  @DisplayName("특정 카테고리를 조회한다.")
+  public void findByCategory() {
+    String category = "001";
+    for (int i = 0; i < 10; i++) {
+      productRepository.save(Product.builder()
+          .productId(i)
+          .productName("고급 신발")
+          .brand("고급 브랜드")
+          .category(category)
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+      productRepository.save(Product.builder()
+          .productId(10 + i)
+          .productName("모자")
+          .brand("신발 최강")
+          .category("003")
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+      productRepository.save(Product.builder()
+          .productId(20 + i)
+          .productName("편한 셔츠")
+          .brand("일반 브랜드")
+          .category("002")
+          .img("http://cdn.img?id=10000_125.jpg")
+          .modifiedDate(LocalDateTime.now())
+          .build());
+    }
+
+    Page<ProductResponseDto> productPage = productQueryRepository
+        .findByCategory(category, LocalDateTime.now().toLocalDate(), PageRequest.of(0, 10));
+    List<ProductResponseDto> productList = productPage.getContent();
+    assertEquals(productPage.getTotalElements(), 10);
+    productList.stream().forEach(i -> assertTrue(i.getCategory().equals(category)));
   }
 
   @Test
@@ -123,7 +189,7 @@ public class ProductQueryRepositoryTest {
 
   @Test
   @DisplayName("마지막 업데이트된 시간을 조회한다")
-  public void findLastModifiedDate() throws Exception{
+  public void findLastModifiedDate() throws Exception {
     String productName = "고급 신발";
     String brand = "고급 브랜드";
     String category = "001";
@@ -143,7 +209,7 @@ public class ProductQueryRepositoryTest {
     LocalDateTime result = productQueryRepository.findLastUpdateDate();
     List<Product> productList = productRepository.findAll();
     LocalDateTime lastModifiedDate = productList.get(0).getModifiedDate();
-    for(Product product : productList){
+    for (Product product : productList) {
       lastModifiedDate = product.getModifiedDate().isAfter(lastModifiedDate)
           ? product.getModifiedDate()
           : lastModifiedDate;

--- a/src/test/java/com/musinsa/watcher/service/CacheServiceTest.java
+++ b/src/test/java/com/musinsa/watcher/service/CacheServiceTest.java
@@ -92,7 +92,7 @@ public class CacheServiceTest {
     when(cache.get(eq(DATE_KEY))).thenReturn(valueWrapper);
     when(valueWrapper.get()).thenReturn(now);
     //when
-    LocalDate result = cacheService.getLastUpdatedByCache();
+    LocalDate result = cacheService.getLastUpdatedDate();
     //then
     assertEquals(result, now.toLocalDate());
   }
@@ -110,7 +110,7 @@ public class CacheServiceTest {
     when(productRepository.findLastUpdateDate()).thenReturn(now);
     when(cache.putIfAbsent(eq(DATE_KEY), eq(now))).thenReturn(valueWrapper);
     //when
-    LocalDate result = cacheService.getLastUpdatedByCache();
+    LocalDate result = cacheService.getLastUpdatedDate();
     //then
     verify(cache, times(1)).putIfAbsent(eq(DATE_KEY), eq(now));
   }


### PR DESCRIPTION
### 목적 
테스트 커버리지 최소 값 설정,  카테고리 조회 쿼리 변경, 테스트 코드 보완
### 원인
전체 날짜에 대해서 카테고리를 조회하고 정렬하는 쿼리는 다소 비용이 든다. 클라이언트가 보내는 api를 분석해봤을 때, 단순히 카테고리 조회 api는 10page이상 호출되는 경우가 거의 없었다. 따라서 당일에 해당하는 데이터만 집계해도 400page분량의 충분한 컨텐츠가 제공된다. 

테스트 커버리지가 낮은 경우 빌드를 실패하게 설정하면 테스트 로직에 좀 더 신경쓸 수 있다고 판단했다.
### 내용
1. 카테고리 조회 쿼리 변경 (기존 : 전체 날짜 집계 + 정렬 -> 현재 : 당일 집계 + 정렬 )  
2. jacoco 테스트 커버리지 최소 값 설정
3. 불필요한 import구문 모두 제거 
4. 카테고리 조회 테스트 코드 추가 작성
5. 코드 리팩토링 (최근 업데이트 날짜를 sql조회 대신 캐시 활용)