### PR TITLE
[Fix] 역대 최저가 조회 쿼리 변경

### DIFF
--- a/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
+++ b/src/main/java/com/musinsa/watcher/domain/product/ProductRepository.java
@@ -47,53 +47,53 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
   List<Object[]> countDiscountProductEachCategory(LocalDate date);
 
   @Query(value =
-      "select p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date, today_price, max_price from \n"
+      "select p1.product_id, p1.product_name, p1.brand, p1.img, p1.modified_date, today_price, avg_price from \n"
           + "(SELECT p1.product_id,  p1.product_name, p1.brand, p1.img, p1.modified_date,\n"
-          + "min(real_price) as min_price, max(real_price) as max_price\n"
+          + "min(real_price) as min_price, avg(real_price) as avg_price\n"
           + "FROM product p1 \n"
           + "inner join price p2 on p1.product_id = p2.product_id\n"
           + "where p1.category = ?1  and p1.modified_date > ?2\n"
-          + "group by p1.product_id having min_price != max_price and count(p2.created_date) > 5 order by null ) p1\n"
+          + "group by p1.product_id having min_price != avg_price and count(p2.created_date) > 5 order by null ) p1\n"
           + "inner join \n"
           + "(SELECT p1.product_id, p1.real_price as today_price\n"
           + "FROM price p1 \n"
           + "where p1.created_date > ?2) p2\n"
           + "on p1.product_id = p2.product_id\n"
-          + "where min_price = today_price and max_price - min_price > max_price/20\n"
-          + "order by (max_price - min_price)/max_price DESC limit ?3, ?4",
+          + "where min_price = today_price and avg_price - min_price > avg_price/20\n"
+          + "order by (avg_price - min_price)/avg_price DESC limit ?3, ?4",
       nativeQuery = true)
   List<Object[]> findProductByMinimumPrice(String category, LocalDate date, long offset, int limit);
 
   @Cacheable(value = "productCache", key = "'minimum count'+#category")
   @Query(value = "select count(p1.product_id) from \n"
-      + "(SELECT p1.product_id, min(real_price) as min_price, max(real_price) as max_price\n"
+      + "(SELECT p1.product_id, min(real_price) as min_price, avg(real_price) as avg_price\n"
       + "FROM product p1 \n"
       + "inner join price p2 on p1.product_id = p2.product_id\n"
       + "where p1.category = ?1  and p1.modified_date > ?2\n"
-      + "group by p1.product_id having min_price != max_price and count(p2.created_date) > 5 order by null ) p1\n"
+      + "group by p1.product_id having min_price != avg_price and count(p2.created_date) > 5 order by null ) p1\n"
       + "inner join \n"
       + "(SELECT p1.product_id, p1.real_price as today_price\n"
       + "FROM price p1 \n"
       + "where p1.created_date > ?2) p2\n"
       + "on p1.product_id = p2.product_id\n"
-      + "where min_price = today_price and max_price - min_price > max_price/20;",
+      + "where min_price = today_price and avg_price - min_price > avg_price/20;",
       nativeQuery = true)
   long countMinimumPrice(String category, LocalDate date);
 
   @Query(value =
       "select category, count(category) from \n"
           + "(SELECT p1.product_id, p1.category,\n"
-          + " min(p2.real_price) as min_price, max(p2.real_price) as max_price\n"
+          + " min(p2.real_price) as min_price, avg(p2.real_price) as avg_price\n"
           + "FROM product p1 \n"
           + "inner join price p2 on p1.product_id = p2.product_id\n"
-          + "group by p1.product_id having min_price != max_price and count(p2.created_date) > 5) p1\n"
+          + "group by p1.product_id having min_price != avg_price and count(p2.created_date) > 5) p1\n"
           + "inner join \n"
           + "(SELECT p1.product_id, p1.real_price as today_price\n"
           + "FROM price p1 \n"
           + "where p1.created_date > ?1) p2\n"
           + "on p1.product_id = p2.product_"
           + "id\n"
-          + "where min_price = today_price and max_price - min_price > max_price/20 \n"
+          + "where min_price = today_price and avg_price - min_price > avg_price/20 \n"
           + "group by category",
       nativeQuery = true)
   List<Object[]> countMinimumPriceProductEachCategory(LocalDate date);

--- a/src/main/java/com/musinsa/watcher/web/dto/MinimumPriceProductDto.java
+++ b/src/main/java/com/musinsa/watcher/web/dto/MinimumPriceProductDto.java
@@ -1,7 +1,7 @@
 package com.musinsa.watcher.web.dto;
 
 import java.io.Serializable;
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
@@ -18,15 +18,15 @@ public class MinimumPriceProductDto implements Serializable {
   private String img;
   private LocalDate modifiedDate;
   private int today_price;
-  private int maxPrice;
+  private int avgPrice;
 
   @Builder
   public MinimumPriceProductDto(int productId, String productName, String brand,
-      String img, Timestamp modifiedDate, int today_price, int maxPrice) {
+      String img, Timestamp modifiedDate, int today_price, int avgPrice) {
     this.productId = productId;
     this.productName = productName;
     this.today_price = today_price;
-    this.maxPrice = maxPrice;
+    this.avgPrice = avgPrice;
     this.brand = brand;
     this.img = img;
     this.modifiedDate = modifiedDate.toLocalDateTime().toLocalDate();
@@ -41,7 +41,7 @@ public class MinimumPriceProductDto implements Serializable {
         .img((String) object[3])
         .modifiedDate((Timestamp) object[4])
         .today_price(((int) object[5]))
-        .maxPrice(((int) object[6]))
+        .avgPrice(((BigDecimal) object[6]).intValue())
         .build();
   }
 

--- a/src/test/java/com/musinsa/watcher/web/dto/MinimumPriceProductDtoTest.java
+++ b/src/test/java/com/musinsa/watcher/web/dto/MinimumPriceProductDtoTest.java
@@ -3,7 +3,6 @@ package com.musinsa.watcher.web.dto;
 import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -21,7 +20,7 @@ public class MinimumPriceProductDtoTest {
     Object productName = "name";
     Object brand = "brand";
     Object img = "url";
-    Object maxPrice = 10000;
+    Object avgPrice = new BigDecimal(10000);
     Object today_price = 7000;
     Object modifiedDate = Timestamp.from(Instant.now());
     MinimumPriceProductDto testDto = MinimumPriceProductDto
@@ -29,14 +28,14 @@ public class MinimumPriceProductDtoTest {
         .productId((int) productId)
         .productName((String) productName)
         .brand((String) brand)
-        .maxPrice(((int) maxPrice))
+        .avgPrice(((BigDecimal) avgPrice).intValue())
         .today_price((int)today_price)
         .img((String) img)
         .modifiedDate((Timestamp) modifiedDate)
         .build();
 
     Object[] objects = new Object[]{productId, productName, brand, img, modifiedDate, today_price,
-        maxPrice};
+        avgPrice};
     List<Object[]> list = new ArrayList<>();
     list.add(objects);
     //when
@@ -44,7 +43,7 @@ public class MinimumPriceProductDtoTest {
         .objectsToDtoList(list);
     //then
     MinimumPriceProductDto minimumPriceProductDto = minimumPriceProductDtoList.get(0);
-    assertEquals(testDto.getMaxPrice(), minimumPriceProductDto.getMaxPrice());
+    assertEquals(testDto.getAvgPrice(), minimumPriceProductDto.getAvgPrice());
     assertEquals(testDto.getToday_price(), minimumPriceProductDto.getToday_price());
     assertEquals(testDto.getBrand(), minimumPriceProductDto.getBrand());
     assertEquals(testDto.getImg(), minimumPriceProductDto.getImg());


### PR DESCRIPTION
### 목적
역대 최저가 조회 쿼리 변경
### 원인 
#87 
### 내용
#88 
1. 평균가대비 오늘 구매가가 낮은 상품 순으로 정렬
