### PR TITLE
[Add] 로컬 캐시, 서킷 브레이커 적용

### DIFF
--- a/.github/workflows/spring-deploy-dev.yml
+++ b/.github/workflows/spring-deploy-dev.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Dev sever scp deploy folder
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.NCP_SERVER1_HOST }}
-          username: ${{ secrets.NCP_SERVER1_USERNAME }}
-          password: ${{ secrets.NCP_SERVER1_PASSWORD }}
-          port: ${{ secrets.NCP_SERVER1_PORT }}
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USERNAME }}
+          password: ${{ secrets.DEV_SERVER_PASSWORD }}
+          port: ${{ secrets.DEV_SERVER_PORT }}
           source: "./deploy/*"
           target: "~/"
           overwrite: true
@@ -61,10 +61,10 @@ jobs:
       - name: Dev sever deploy
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.NCP_SERVER1_HOST }}
-          username: ${{ secrets.NCP_SERVER1_USERNAME }}
-          password: ${{ secrets.NCP_SERVER1_PASSWORD }}
-          port: ${{ secrets.NCP_SERVER1_PORT }}
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USERNAME }}
+          password: ${{ secrets.DEV_SERVER_PASSWORD }}
+          port: ${{ secrets.DEV_SERVER_PORT }}
           script: |
             cd deploy
             sudo bash deploy.sh

--- a/build.gradle
+++ b/build.gradle
@@ -42,11 +42,16 @@ jacocoTestReport {
     }
 }
 jacocoTestCoverageVerification {
-    violationRules {
-        enabled = true
-        rule {
-            excludes = ["*.QA*", "*.QP*", "*.QB*"]
+    def Qdomains = []
 
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+
+        rule {
+            enabled = true
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
@@ -58,6 +63,7 @@ jacocoTestCoverageVerification {
                 value = 'COVEREDRATIO'
                 minimum = 0.80
             }
+            excludes = [] + Qdomains
         }
     }
 }
@@ -88,6 +94,7 @@ dependencies {
     annotationProcessor("com.querydsl:querydsl-apt:4.3.1:jpa") // querydsl JPAAnnotationProcessor 사용 지정
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.1.0.RELEASE")
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.springframework.boot:spring-boot-starter-cache')
     compile('org.projectlombok:lombok')
@@ -99,6 +106,7 @@ dependencies {
     annotationProcessor('org.projectlombok:lombok')
     compile('org.springframework.boot:spring-boot-starter-data-redis')
     compile group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+    compile group: 'net.sf.ehcache', name: 'ehcache', version: '2.10.3'
     testAnnotationProcessor('org.projectlombok:lombok')
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testImplementation "org.mockito:mockito-core:3.5.9"

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -4,4 +4,4 @@ cd ~/kubernetes/
 
 CONFIG_FILE=$(echo kubeconfig*)
 
-kubectl --kubeconfig=$CONFIG_FILE rollout restart deployments/api-server1
+kubectl --kubeconfig=$CONFIG_FILE rollout restart deployments/watcher-api-dp

--- a/src/main/java/com/musinsa/watcher/WatcherApplication.java
+++ b/src/main/java/com/musinsa/watcher/WatcherApplication.java
@@ -2,11 +2,11 @@ package com.musinsa.watcher;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableCaching
 @EnableJpaAuditing
+@EnableCircuitBreaker
 @SpringBootApplication
 public class WatcherApplication {
 

--- a/src/main/java/com/musinsa/watcher/config/cache/CacheConfig.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/CacheConfig.java
@@ -1,0 +1,55 @@
+package com.musinsa.watcher.config.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+@EnableCaching
+public class CacheConfig extends CachingConfigurerSupport {
+
+  private final RedisConnectionFactory connectionFactory;
+
+  @Bean
+  public EhCacheManagerFactoryBean ehCacheManagerFactoryBean() {
+    EhCacheManagerFactoryBean ehCacheManagerFactoryBean = new EhCacheManagerFactoryBean();
+    ehCacheManagerFactoryBean.setConfigLocation(
+        new ClassPathResource("ehcache.xml"));
+    ehCacheManagerFactoryBean.setShared(true);
+    return ehCacheManagerFactoryBean;
+  }
+
+  @Bean
+  public EhCacheCacheManager ehCacheCacheManager(EhCacheManagerFactoryBean ehCacheManagerFactoryBean) {
+    EhCacheCacheManager ehCacheCacheManager = new EhCacheCacheManager();
+    ehCacheCacheManager.setCacheManager(ehCacheManagerFactoryBean.getObject());
+    return ehCacheCacheManager;
+  }
+  @Bean
+  public CacheManager globalCacheManager() {
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
+    RedisCacheManager redisCacheManager = RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    return redisCacheManager;
+  }
+
+  @Bean
+  @Primary
+  @Override
+  public CacheManager cacheManager() {
+    return new ChainedCacheManager(ehCacheCacheManager(ehCacheManagerFactoryBean()), globalCacheManager());
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/ChainedCache.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/ChainedCache.java
@@ -1,0 +1,98 @@
+package com.musinsa.watcher.config.cache;
+
+import com.musinsa.watcher.config.cache.hystrix.HystrixClearCommand;
+import com.musinsa.watcher.config.cache.hystrix.HystrixEvictCommand;
+import com.musinsa.watcher.config.cache.hystrix.HystrixGetCommand;
+import com.musinsa.watcher.config.cache.hystrix.HystrixPutCommand;
+import com.musinsa.watcher.config.cache.hystrix.HystrixPutIfAbsentCommand;
+import java.util.List;
+import java.util.concurrent.Callable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+
+@Slf4j
+public class ChainedCache implements Cache {
+
+  private final Cache localCache;
+  private final Cache globalCache;
+
+  public ChainedCache(List<Cache> caches) {
+    this.localCache = caches.get(0);
+    this.globalCache = caches.get(1);
+  }
+
+  @Override
+  public ValueWrapper get(Object key) {
+    ValueWrapper valueWrapper = localCache.get(key);
+    log.info("로컬 캐시 : " + valueWrapper);
+    if (valueWrapper != null && valueWrapper.get() != null) {
+      log.info("로컬 캐시 조회");
+      return valueWrapper;
+    } else {
+      valueWrapper = new HystrixGetCommand(globalCache, key).execute();
+      log.info("글로벌 캐시 : " + valueWrapper);
+      if(valueWrapper != null){
+        localCache.put(key, valueWrapper.get());
+      }
+      return valueWrapper;
+    }
+  }
+
+
+  @Override
+  public ValueWrapper putIfAbsent(Object key, Object value) {
+    log.info("putIfAbsent");
+    return new HystrixPutIfAbsentCommand(localCache, globalCache, key, value).execute();
+  }
+
+  @Override
+  public boolean evictIfPresent(Object key) {
+    log.info("evictIfPresent");
+    return localCache.evictIfPresent(key);
+  }
+
+  @Override
+  public boolean invalidate() {
+    log.info("invalidate");
+    return localCache.invalidate();
+  }
+
+  @Override
+  public String getName() {
+      return localCache.getName();
+  }
+
+  @Override
+  public Object getNativeCache() {
+    log.info("command되지않은 getNativeCache발동");
+    return localCache.getNativeCache();
+  }
+
+  @Override
+  public <T> T get(Object key, Class<T> type) {
+    log.info("command되지않은 get발동");
+    return localCache.get(key, type);
+  }
+
+  @Override
+  public <T> T get(Object key, Callable<T> valueLoader) {
+    log.info("command되지않은 get발동");
+    return localCache.get(key, valueLoader);
+  }
+
+  @Override
+  public void put(Object key, Object value) {
+    new HystrixPutCommand(localCache, globalCache, key, value).execute();
+  }
+
+  @Override
+  public void evict(Object key) {
+    new HystrixEvictCommand(localCache, globalCache, key);
+  }
+
+  @Override
+  public void clear() {
+    new HystrixClearCommand(localCache, globalCache);
+  }
+
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/ChainedCacheManager.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/ChainedCacheManager.java
@@ -1,0 +1,40 @@
+package com.musinsa.watcher.config.cache;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.lang.NonNull;
+
+public class ChainedCacheManager implements CacheManager {
+  private final List<CacheManager> cacheManagers;
+  private final Map<String, Cache> cacheMap = new ConcurrentHashMap<>();
+
+  public ChainedCacheManager(@NonNull CacheManager... cacheManagers) {
+    if (cacheManagers.length < 1) {
+      throw new IllegalArgumentException();
+    }
+    this.cacheManagers = Collections.unmodifiableList(Arrays.asList(cacheManagers));
+  }
+
+  @Override
+  public Cache getCache(String name) {
+    return cacheMap.computeIfAbsent(name, key -> new ChainedCache(getCaches(key)));
+  }
+
+  private List<Cache> getCaches(String name) {
+    return cacheManagers.stream().map(manager -> manager.getCache(name)).collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<String> getCacheNames() {
+    return cacheManagers.stream()
+        .flatMap(manager -> manager.getCacheNames().stream())
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixClearCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixClearCommand.java
@@ -15,14 +15,15 @@ public class HystrixClearCommand extends HystrixCommand {
   private final Cache localCache;
 
   public HystrixClearCommand(Cache localCache, Cache globalCache) {
-    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
-        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("cacheGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-clear"))
         .andCommandPropertiesDefaults(
             HystrixCommandProperties.defaultSetter()
                 .withExecutionTimeoutInMilliseconds(1000)
                 .withCircuitBreakerErrorThresholdPercentage(50)
-                .withCircuitBreakerRequestVolumeThreshold(5)
-                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+                .withCircuitBreakerRequestVolumeThreshold(10)
+                .withCircuitBreakerSleepWindowInMilliseconds(30000)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)));
     this.globalCache = globalCache;
     this.localCache = localCache;
   }

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixClearCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixClearCommand.java
@@ -1,0 +1,47 @@
+package com.musinsa.watcher.config.cache.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+
+@Slf4j
+public class HystrixClearCommand extends HystrixCommand {
+
+  private final Cache globalCache;
+  private final Cache localCache;
+
+  public HystrixClearCommand(Cache localCache, Cache globalCache) {
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.defaultSetter()
+                .withExecutionTimeoutInMilliseconds(1000)
+                .withCircuitBreakerErrorThresholdPercentage(50)
+                .withCircuitBreakerRequestVolumeThreshold(5)
+                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+    this.globalCache = globalCache;
+    this.localCache = localCache;
+  }
+
+  @Override
+  protected Object run() {
+    localCache.clear();
+    globalCache.clear();
+    log.info("로컬 clear");
+    log.info("글로벌 clear");
+    return null;
+  }
+
+  @Override
+  protected ValueWrapper getFallback() {
+    log.warn("cache clear fallback called, circuit is {}",super.circuitBreaker.isOpen());
+    localCache.clear();
+    log.info("로컬 clear");
+    return null;
+  }
+
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixEvictCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixEvictCommand.java
@@ -1,0 +1,48 @@
+package com.musinsa.watcher.config.cache.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+
+@Slf4j
+public class HystrixEvictCommand extends HystrixCommand {
+
+  private final Cache globalCache;
+  private final Cache localCache;
+  private final Object key;
+
+  public HystrixEvictCommand(Cache localCache, Cache globalCache, Object key) {
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.defaultSetter()
+                .withExecutionTimeoutInMilliseconds(1000)
+                .withCircuitBreakerErrorThresholdPercentage(50)
+                .withCircuitBreakerRequestVolumeThreshold(5)
+                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+    this.globalCache = globalCache;
+    this.localCache = localCache;
+    this.key = key;
+  }
+
+  @Override
+  protected Object run() {
+    localCache.evict(key);
+    globalCache.evict(key);
+    log.info("로컬 evict");
+    log.info("글로벌 evict");
+    return null;
+  }
+
+  @Override
+  protected ValueWrapper getFallback() {
+    log.warn("cache evict fallback called, circuit is {}",super.circuitBreaker.isOpen());
+    localCache.evict(key);
+    log.info("로컬 evict");
+    return null;
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixEvictCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixEvictCommand.java
@@ -16,14 +16,15 @@ public class HystrixEvictCommand extends HystrixCommand {
   private final Object key;
 
   public HystrixEvictCommand(Cache localCache, Cache globalCache, Object key) {
-    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
-        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("cacheGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-evict"))
         .andCommandPropertiesDefaults(
             HystrixCommandProperties.defaultSetter()
                 .withExecutionTimeoutInMilliseconds(1000)
                 .withCircuitBreakerErrorThresholdPercentage(50)
-                .withCircuitBreakerRequestVolumeThreshold(5)
-                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+                .withCircuitBreakerRequestVolumeThreshold(10)
+                .withCircuitBreakerSleepWindowInMilliseconds(30000)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)));
     this.globalCache = globalCache;
     this.localCache = localCache;
     this.key = key;

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixGetCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixGetCommand.java
@@ -1,0 +1,41 @@
+package com.musinsa.watcher.config.cache.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.context.annotation.Bean;
+
+@Slf4j
+public class HystrixGetCommand extends HystrixCommand<ValueWrapper> {
+  private final Cache globalCache;
+  private final Object key;
+
+  public HystrixGetCommand(Cache globalCache, Object key) {
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.defaultSetter()
+                .withExecutionTimeoutInMilliseconds(1000)
+                .withCircuitBreakerErrorThresholdPercentage(50)
+                .withCircuitBreakerRequestVolumeThreshold(5)
+                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+    this.globalCache = globalCache;
+    this.key = key;
+  }
+
+  @Override
+  protected ValueWrapper run() {
+    log.info("글로벌 get");
+    return globalCache.get(key);
+  }
+
+  @Override
+  protected ValueWrapper getFallback() {
+    log.warn("get fallback called, circuit is {}", super.circuitBreaker.isOpen());
+    return null;
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixGetCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixGetCommand.java
@@ -15,14 +15,15 @@ public class HystrixGetCommand extends HystrixCommand<ValueWrapper> {
   private final Object key;
 
   public HystrixGetCommand(Cache globalCache, Object key) {
-    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("cacheGroupKey"))
         .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
         .andCommandPropertiesDefaults(
             HystrixCommandProperties.defaultSetter()
                 .withExecutionTimeoutInMilliseconds(1000)
                 .withCircuitBreakerErrorThresholdPercentage(50)
-                .withCircuitBreakerRequestVolumeThreshold(5)
-                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+                .withCircuitBreakerRequestVolumeThreshold(10)
+                .withCircuitBreakerSleepWindowInMilliseconds(30000)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)));
     this.globalCache = globalCache;
     this.key = key;
   }

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutCommand.java
@@ -16,14 +16,15 @@ public class HystrixPutCommand extends HystrixCommand {
   private final Object value;
 
   public HystrixPutCommand(Cache localCache, Cache globalCache, Object key, Object value) {
-    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
-        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("cacheGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-put"))
         .andCommandPropertiesDefaults(
             HystrixCommandProperties.defaultSetter()
                 .withExecutionTimeoutInMilliseconds(1000)
                 .withCircuitBreakerErrorThresholdPercentage(50)
-                .withCircuitBreakerRequestVolumeThreshold(5)
-                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+                .withCircuitBreakerRequestVolumeThreshold(10)
+                .withCircuitBreakerSleepWindowInMilliseconds(30000)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)));
     this.globalCache = globalCache;
     this.localCache = localCache;
     this.key = key;

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutCommand.java
@@ -1,0 +1,49 @@
+package com.musinsa.watcher.config.cache.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+
+@Slf4j
+public class HystrixPutCommand extends HystrixCommand {
+
+  private final Cache globalCache;
+  private final Cache localCache;
+  private final Object key;
+  private final Object value;
+
+  public HystrixPutCommand(Cache localCache, Cache globalCache, Object key, Object value) {
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.defaultSetter()
+                .withExecutionTimeoutInMilliseconds(1000)
+                .withCircuitBreakerErrorThresholdPercentage(50)
+                .withCircuitBreakerRequestVolumeThreshold(5)
+                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+    this.globalCache = globalCache;
+    this.localCache = localCache;
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  protected Object run() {
+    localCache.put(key, value);
+    globalCache.put(key, value);
+    log.info("글로벌 put");
+    log.info("로컬 put");
+    return null;
+  }
+
+  @Override
+  protected Object getFallback() {
+    log.warn("put fallback called, circuit is {}", super.circuitBreaker.isOpen());
+    localCache.put(key, value);
+    log.info("로컬 put");
+    return null;
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutIfAbsentCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutIfAbsentCommand.java
@@ -1,0 +1,50 @@
+package com.musinsa.watcher.config.cache.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+
+@Slf4j
+public class HystrixPutIfAbsentCommand extends HystrixCommand<ValueWrapper> {
+
+  private final Cache globalCache;
+  private final Cache localCache;
+  private final Object key;
+  private final Object value;
+
+  public HystrixPutIfAbsentCommand(Cache localCache, Cache globalCache, Object key, Object value) {
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.defaultSetter()
+                .withExecutionTimeoutInMilliseconds(1000)
+                .withCircuitBreakerErrorThresholdPercentage(50)
+                .withCircuitBreakerRequestVolumeThreshold(5)
+                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+    this.globalCache = globalCache;
+    this.localCache = localCache;
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  protected ValueWrapper run() {
+    localCache.putIfAbsent(key, value);
+    globalCache.putIfAbsent(key, value);
+    log.info("글로벌 putIfAbsent");
+    log.info("로컬 putIfAbsent");
+    return null;
+  }
+
+  @Override
+  protected ValueWrapper getFallback() {
+    log.warn("putIfAbsent fallback called, circuit is {}", super.circuitBreaker.isOpen());
+    localCache.putIfAbsent(key, value);
+    log.info("로컬 putIfAbsent");
+    return null;
+  }
+}

--- a/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutIfAbsentCommand.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/hystrix/HystrixPutIfAbsentCommand.java
@@ -17,14 +17,15 @@ public class HystrixPutIfAbsentCommand extends HystrixCommand<ValueWrapper> {
   private final Object value;
 
   public HystrixPutIfAbsentCommand(Cache localCache, Cache globalCache, Object key, Object value) {
-    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testGroupKey"))
-        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-get"))
+    super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("cacheGroupKey"))
+        .andCommandKey(HystrixCommandKey.Factory.asKey("cache-putIfAbsent"))
         .andCommandPropertiesDefaults(
             HystrixCommandProperties.defaultSetter()
                 .withExecutionTimeoutInMilliseconds(1000)
                 .withCircuitBreakerErrorThresholdPercentage(50)
-                .withCircuitBreakerRequestVolumeThreshold(5)
-                .withMetricsRollingStatisticalWindowInMilliseconds(20000)));
+                .withCircuitBreakerRequestVolumeThreshold(10)
+                .withCircuitBreakerSleepWindowInMilliseconds(30000)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)));
     this.globalCache = globalCache;
     this.localCache = localCache;
     this.key = key;

--- a/src/main/java/com/musinsa/watcher/web/PriceController.java
+++ b/src/main/java/com/musinsa/watcher/web/PriceController.java
@@ -11,8 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@CrossOrigin({"http://www.musinsa.cf/", "http://api.musinsa.cf/, https://www.musinsa.cf/",
-    "https://api.musinsa.cf/"})
+@CrossOrigin(origins = {"*"})
 @RequiredArgsConstructor
 @RestController
 public class PriceController {

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"
+  updateCheck="false">
+  <diskStore path="java.io.tmpdir" />
+
+  <cache name="productCache"
+    maxEntriesLocalHeap="10000"
+    eternal="false"
+    diskSpoolBufferSizeMB="20"
+    timeToLiveSeconds="10"
+    memoryStoreEvictionPolicy="LFU"
+    transactionalMode="off">
+    <persistence strategy="localTempSwap" />
+  </cache>
+
+</ehcache>

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -7,9 +7,8 @@
   <cache name="productCache"
     maxEntriesLocalHeap="10000"
     eternal="false"
-    diskSpoolBufferSizeMB="20"
-    timeToLiveSeconds="10"
-    memoryStoreEvictionPolicy="LFU"
+    timeToLiveSeconds="60000"
+    memoryStoreEvictionPolicy="LRU"
     transactionalMode="off">
     <persistence strategy="localTempSwap" />
   </cache>

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -7,7 +7,7 @@
   <cache name="productCache"
     maxEntriesLocalHeap="10000"
     eternal="false"
-    timeToLiveSeconds="60000"
+    timeToLiveSeconds="600"
     memoryStoreEvictionPolicy="LRU"
     transactionalMode="off">
     <persistence strategy="localTempSwap" />

--- a/src/test/java/com/musinsa/watcher/config/ChainedCacheMangerTest.java
+++ b/src/test/java/com/musinsa/watcher/config/ChainedCacheMangerTest.java
@@ -1,0 +1,29 @@
+package com.musinsa.watcher.config;
+
+import static org.junit.Assert.*;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class ChainedCacheMangerTest {
+
+  @Autowired
+  private CacheManager cacheManager;
+
+  @Test
+  @DisplayName("지정한 2차 cache manager를 사용한다")
+  public void getGlobalCache() {
+    assertEquals("com.musinsa.watcher.config.cache.ChainedCacheManager",
+        cacheManager.getClass().getName());
+  }
+
+}

--- a/src/test/java/com/musinsa/watcher/config/cache/ChainedCacheTest.java
+++ b/src/test/java/com/musinsa/watcher/config/cache/ChainedCacheTest.java
@@ -1,0 +1,165 @@
+package com.musinsa.watcher.config.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+public class ChainedCacheTest {
+
+  @Mock
+  private Cache localCache;
+
+  @Mock
+  private Cache globalCache;
+
+  @Test
+  @DisplayName("local cache가 없다면 global cache 사용한다")
+  public void useGlobalCache() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper valueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(null);
+    when(globalCache.get(eq(key))).thenReturn(valueWrapper);
+    when(valueWrapper.get()).thenReturn(value);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, valueWrapper);
+  }
+
+  @Test
+  @DisplayName("local cache에 value가 없다면 global cache를 사용한다")
+  public void useGlobalCache2() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper lovalValueWrapper = mock(ValueWrapper.class);
+    ValueWrapper globalValueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(lovalValueWrapper);
+    when(globalCache.get(eq(key))).thenReturn(globalValueWrapper);
+    when(globalValueWrapper.get()).thenReturn(value);
+    when(lovalValueWrapper.get()).thenReturn(null);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, globalValueWrapper);
+  }
+
+  @Test
+  @DisplayName("둘 다 cache가 없다면 null을 반환한다.")
+  public void nullCache() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper valueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(null);
+    when(globalCache.get(eq(key))).thenReturn(null);
+    when(valueWrapper.get()).thenReturn(value);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, null);
+  }
+
+  @Test
+  @DisplayName("local cache가 있다면 local cache를 사용한다")
+  public void useLocalCache() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper valueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(valueWrapper);
+    when(valueWrapper.get()).thenReturn(value);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, valueWrapper);
+  }
+
+  @Test
+  @DisplayName("global cache에 오류가 있다면 fallback이 발동된다.")
+  public void useFallback() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper valueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(null);
+    when(globalCache.get(eq(key))).thenThrow(new RuntimeException());
+    when(valueWrapper.get()).thenReturn(value);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, null);
+  }
+
+  @Test
+  @DisplayName("global cache가 존재하면 local cache에 저장한다.")
+  public void putCache() {
+    //given
+    String key = "key1";
+    String value = "value1";
+    ValueWrapper valueWrapper = mock(ValueWrapper.class);
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+    when(localCache.get(eq(key))).thenReturn(null);
+    when(globalCache.get(eq(key))).thenReturn(valueWrapper);
+    when(valueWrapper.get()).thenReturn(value);
+
+    //when
+    ValueWrapper result = cache.get(key);
+
+    //then
+    assertEquals(result, valueWrapper);
+    verify(localCache, times(1)).put(eq(key), eq(value));
+  }
+
+
+}

--- a/src/test/java/com/musinsa/watcher/service/CacheServiceIntegratationTest.java
+++ b/src/test/java/com/musinsa/watcher/service/CacheServiceIntegratationTest.java
@@ -1,0 +1,101 @@
+package com.musinsa.watcher.service;
+
+import static org.junit.Assert.assertEquals;
+
+import com.musinsa.watcher.domain.product.Product;
+import com.musinsa.watcher.domain.product.ProductRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class CacheServiceIntegratationTest {
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @Autowired
+  private CacheService cacheService;
+
+  @Autowired
+  private CacheManager cacheManager;
+
+  @Before
+  public void clean() {
+    cacheManager.getCache("productCache").clear();
+    productRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("캐시를 사용하여 호출한다.")
+  public void callCache() {
+    LocalDateTime localDateTime1 = LocalDateTime.now();
+    LocalDateTime localDateTime2 = localDateTime1.plusDays(3);
+    productRepository.save(Product.builder()
+        .productId(1)
+        .productName("고급 신발")
+        .brand("고급 브랜드")
+        .category("001")
+        .img("http://cdn.img?id=10000_125.jpg")
+        .modifiedDate(localDateTime1)
+        .build());
+    cacheService.updateCacheByDate();
+    productRepository.save(Product.builder()
+        .productId(2)
+        .productName("고급 신발")
+        .brand("고급 브랜드")
+        .category("001")
+        .img("http://cdn.img?id=10000_125.jpg")
+        .modifiedDate(localDateTime2)
+        .build());
+
+    cacheService.getLastUpdatedDate();
+    LocalDate localDate = cacheService.getLastUpdatedDate();
+
+    assertEquals(localDate, localDateTime1.toLocalDate());
+  }
+
+  @Test
+  @DisplayName("캐시를 초기화 한다.")
+  public void clearCache() {
+    //given
+    LocalDateTime localDateTime1 = LocalDateTime.now();
+    LocalDateTime localDateTime2 = localDateTime1.plusMinutes(1L);
+    productRepository.save(Product.builder()
+        .productId(1)
+        .productName("고급 신발")
+        .brand("고급 브랜드")
+        .category("001")
+        .img("http://cdn.img?id=10000_125.jpg")
+        .modifiedDate(localDateTime1)
+        .build());
+    //when
+    cacheService.updateCacheByDate();
+    //given
+    productRepository.save(Product.builder()
+        .productId(2)
+        .productName("고급 신발")
+        .brand("고급 브랜드")
+        .category("001")
+        .img("http://cdn.img?id=10000_125.jpg")
+        .modifiedDate(localDateTime2)
+        .build());
+    //when
+    cacheService.updateCacheByDate();
+    LocalDateTime cachedLocalDateTime = (LocalDateTime) cacheManager.getCache("productCache")
+        .get("current date").get();
+
+    //then
+    assertEquals(cachedLocalDateTime, localDateTime2);
+  }
+}


### PR DESCRIPTION
### 목적
캐시 서버 장애에 대처한다.
### 원인
#97 
캐시 서버의 장애가 api서버의 장애로 전파됨
### 내용
1. 로컬 캐시로 ehcache를 적용
2. 글로벌 캐시로 redis를 사용
3. 서킷 브레이커를 적용
4. 테스트 코드 작성
5. 그외 오타 및 명명 변경