### PR TITLE
[Fix] 캐시 초기화 실행이 누락된 부분 수정

### DIFF
--- a/src/main/java/com/musinsa/watcher/config/cache/ChainedCache.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/ChainedCache.java
@@ -92,7 +92,7 @@ public class ChainedCache implements Cache {
 
   @Override
   public void clear() {
-    new HystrixClearCommand(localCache, globalCache);
+    new HystrixClearCommand(localCache, globalCache).execute();
   }
 
 }

--- a/src/test/java/com/musinsa/watcher/config/cache/ChainedCacheTest.java
+++ b/src/test/java/com/musinsa/watcher/config/cache/ChainedCacheTest.java
@@ -161,5 +161,22 @@ public class ChainedCacheTest {
     verify(localCache, times(1)).put(eq(key), eq(value));
   }
 
+  @Test
+  @DisplayName("cache를 초기화하면 local, global cache 둘 다 초기화된다.")
+  public void clearCache() {
+    //given
+    List<Cache> caches = mock(List.class);
+    when(caches.get(eq(0))).thenReturn(localCache);
+    when(caches.get(eq(1))).thenReturn(globalCache);
+    ChainedCache cache = new ChainedCache(caches);
+
+    //when
+    cache.clear();
+
+    //then
+    verify(localCache, times(1)).clear();
+    verify(globalCache, times(1)).clear();
+
+  }
 
 }


### PR DESCRIPTION
### 목적
누락된 메서드 수정
### 원인
메서드가 누락되어 캐시 초기화가 발동하지 않았음
### 내용
1. HysrixCommand에 누락된 excute()를 붙여줌
2. cache clear에 관한 유닛 테스트를 추가함