### PR TITLE
[Add] 로컬 캐시 동기화를 위한 api 및 테스트 코드 작성

### DIFF
--- a/kubernetes/spring.yml
+++ b/kubernetes/spring.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: watcher-api-dp
 spec:
-  replicas: 4
+  replicas: 2
   selector:
     matchLabels:
       app: watcher-api
@@ -19,16 +19,20 @@ spec:
           image: j005580/musinsa-watcher
           livenessProbe:
             httpGet:
-              path: /api/profile
+              path: /api/v1/cache/sycn
               port: 8081
-            initialDelaySeconds: 20
-            timeoutSeconds: 15
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /api/profile
+              path: /api/v1/cache/sycn
               port: 8081
-            initialDelaySeconds: 20
-            timeoutSeconds: 15
+            initialDelaySeconds: 30
+              timeoutSeconds: 5
+              periodSeconds: 10
+              failureThreshold: 5
           env:
             - name: PROPERTIES
               value: config/application-real.properties

--- a/src/main/java/com/musinsa/watcher/web/CacheController.java
+++ b/src/main/java/com/musinsa/watcher/web/CacheController.java
@@ -23,4 +23,9 @@ public class CacheController {
   public String updateDate() {
     return cacheService.getLastUpdatedDate().toString();
   }
+
+  @GetMapping("/api/v1/cache/sycn")
+  public String sycnCache(){
+    return cacheService.doSynchronize() ? "동기화되었습니다." : "이미 동기화되었습니다.";
+  }
 }

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -7,7 +7,7 @@
   <cache name="productCache"
     maxEntriesLocalHeap="10000"
     eternal="false"
-    timeToLiveSeconds="600"
+    timeToLiveSeconds="86400"
     memoryStoreEvictionPolicy="LRU"
     transactionalMode="off">
     <persistence strategy="localTempSwap" />


### PR DESCRIPTION
### 목적
로컬 캐시 동기화
### 원인
#103 
로컬 캐시 동기화로 조회시마다 다른 컨텐츠가 노출 될 수 있음.
### 내용
1. 동기화 api 작성
2. 통합 테스트, 유닛 테스트 작성
3.  k8s livenessProbe, readnessProbe 수정