### PR TITLE
[Add] 브랜드명 클릭시 브랜드 조회 페이지로 이동하는 기능

### DIFF
--- a/frontend-mobile/src/components/ProductDetail.vue
+++ b/frontend-mobile/src/components/ProductDetail.vue
@@ -2,7 +2,7 @@
     <div style="margin-top:50px; margin-bottom:50px">
         <b-container class="bv-example-row">
             <h3 style="text-align : left">
-                <strong>{{product.brand}}</strong>
+                <a :href="'/product/list?brand='+product.brand" style="color : #000000"><strong>{{product.brand}}</strong></a>
             </h3>
             <div style="text-align : left">
                 <span style="font-size : 20px; color :#b2b2b2;">분류 :

--- a/frontend/src/components/ProductDetail.vue
+++ b/frontend/src/components/ProductDetail.vue
@@ -2,7 +2,7 @@
     <div style="margin-top:30px">
         <b-container class="bv-example-row">
             <h3 style="text-align : left">
-                <strong>{{product.brand}}</strong>
+                <a :href="'/product/list?brand='+product.brand" style="color : #000000"><strong>{{product.brand}}</strong></a>
             </h3>
             <div style="text-align : left">
                 <span style="font-size : 20px; color :#b2b2b2;">분류 :

--- a/frontend/src/components/ProductList.vue
+++ b/frontend/src/components/ProductList.vue
@@ -151,7 +151,7 @@
             },
             itemListToCardDeck(list) {
                 var productDeck = []
-                for (var i = 0; i < this.columnCount; i++) {
+                for (var i = 0; i < this.perpage/this.columnCount; i++) {
                     productDeck.push(list.slice(i * this.columnCount, (i + 1) * this.columnCount))
                 }
                 return productDeck


### PR DESCRIPTION
### 목적
간편한 조회를 위해서 브랜드 명 클릭시 브랜드 조회 페이지로 이동할 수 있게 작성
### 원인
브랜드별 상품 조회를 이용하려면 브랜드 조회를 직접 이용해야함. 더 간단한 조회를 위해 기능을 추가
### 내용
1.  상품 상세정보 페이지에서 브랜드명 클릭시 브랜드 조회 페이지로 이동
2.  카드 덱을 구성하는데 row수 계산 방식이 잘못되었던 점 수정