### PR TITLE
key generator로직 단순화, category 파라미터 trim적용

### DIFF
--- a/src/main/java/com/musinsa/watcher/config/cache/CustomKeyGenerator.java
+++ b/src/main/java/com/musinsa/watcher/config/cache/CustomKeyGenerator.java
@@ -2,7 +2,7 @@ package com.musinsa.watcher.config.cache;
 
 import java.lang.reflect.Method;
 import org.springframework.cache.interceptor.KeyGenerator;
-import org.springframework.data.domain.Pageable;
+import org.springframework.cache.interceptor.SimpleKeyGenerator;
 
 public class CustomKeyGenerator implements KeyGenerator {
 
@@ -10,23 +10,7 @@ public class CustomKeyGenerator implements KeyGenerator {
   public Object generate(Object target, Method method, Object... params) {
     StringBuilder keyBuilder = new StringBuilder();
     keyBuilder.append(method.getName());
-    if (params.length > 0) {
-      keyBuilder.append(";");
-      for (Object argument : params) {
-        if (argument instanceof Pageable) {
-          Pageable pageable = (Pageable) argument;
-          keyBuilder.append(pageable.getPageNumber());
-          keyBuilder.append(";");
-          keyBuilder.append(pageable.getPageSize());
-          keyBuilder.append(";");
-          keyBuilder.append(pageable.getSort().toString());
-          keyBuilder.append(";");
-          continue;
-        }
-        keyBuilder.append(argument);
-        keyBuilder.append(";");
-      }
-    }
+    keyBuilder.append(SimpleKeyGenerator.generateKey(params));
     return keyBuilder.toString();
   }
 }

--- a/src/main/java/com/musinsa/watcher/config/webparameter/ParameterHandler.java
+++ b/src/main/java/com/musinsa/watcher/config/webparameter/ParameterHandler.java
@@ -52,6 +52,7 @@ public class ParameterHandler implements HandlerMethodArgumentResolver {
       return null;
     }
     String[] categoryArr = categories.split(",");
-    return Arrays.stream(categoryArr).map(Category::getCategory).toArray(Category[]::new);
+    return Arrays.stream(categoryArr).map(i -> Category.getCategory(i.trim()))
+        .toArray(Category[]::new);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,3 @@ spring.application.name=watcher
 management.endpoints.web.exposure.include=prometheus
 management.metrics.tags.application=${spring.application.name}
 spring.cache.jcache.config=classpath:ehcache.xml
-spring.profiles.include=local

--- a/src/test/java/com/musinsa/watcher/web/ProductControllerTest.java
+++ b/src/test/java/com/musinsa/watcher/web/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.musinsa.watcher.web;
 
+import com.musinsa.watcher.config.webparameter.FilterVo;
 import com.musinsa.watcher.domain.product.Category;
 import com.musinsa.watcher.service.ProductService;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,20 @@ public class ProductControllerTest {
   }
 
   @Test
+  @DisplayName("여러 브랜드를 동시에 조회한다.")
+  public void findProductByBrands() throws Exception {
+    FilterVo filterVo = FilterVo.builder()
+        .brands(new String[]{"나이키", "아디다스", "언더아머"})
+        .build();
+
+    mvc.perform(get(API + "brand")
+        .param("brand", "나이키, 아디다스, 언더아머"))
+        .andExpect(status().isOk());
+
+    verify(mockProductService, only()).findProductsPageByBrand(eq(filterVo), any());
+  }
+
+  @Test
   @DisplayName("카테고리 상품 리스트 조회한다.")
   public void findProductByCategory() throws Exception {
     for (Category category : Category.values()) {
@@ -56,7 +71,22 @@ public class ProductControllerTest {
           .param("maxprice", "10000"))
           .andExpect(status().isOk());
     }
-    verify(mockProductService, times(Category.values().length)).findProductsPageByCategory(any(), any());
+    verify(mockProductService, times(Category.values().length))
+        .findProductsPageByCategory(any(), any());
+  }
+
+  @Test
+  @DisplayName("여러 카테고리를 동시에 조회한다.")
+  public void findProductByCategorys() throws Exception {
+    FilterVo filterVo = FilterVo.builder()
+        .categories(new Category[]{Category.TOP, Category.OUTER, Category.PANTS})
+        .build();
+
+    mvc.perform(get(API + "list")
+        .param("category", "001, 002, 003"))
+        .andExpect(status().isOk());
+
+    verify(mockProductService, only()).findProductsPageByCategory(eq(filterVo), any());
   }
 
   @Test


### PR DESCRIPTION
- key generator 로직중 불필요하게 pageable를 파싱하던 부분 제거, SimpleKeyGenerator추가 사용
- 여러 cateogory 파라미터에서 띄어쓰기가 들어왔을 경우 파싱하지 못하던 문제 수정
- application.properties에서 local을 자동으로 active하는 부분 수정